### PR TITLE
Refine edit-file terminal newline trimming

### DIFF
--- a/tests/approved_files/edit_file_tool_test.test_edit_file_delete_range_extending_past_file_end.approved.txt
+++ b/tests/approved_files/edit_file_tool_test.test_edit_file_delete_range_extending_past_file_end.approved.txt
@@ -1,0 +1,19 @@
+Command:
+🛠️ edit-file test.txt delete 2-10
+
+Result:
+Successfully edited test.txt
+
+Initial file: test.txt
+Initial content:
+--- INITIAL CONTENT START ---
+line1
+line2
+line3
+--- INITIAL CONTENT END ---
+
+File after edit: test.txt
+Final content:
+--- FINAL CONTENT START ---
+line1
+--- FINAL CONTENT END ---

--- a/tests/approved_files/edit_file_tool_test.test_edit_file_replace_range_beyond_file_end_leaves_file_unchanged.approved.txt
+++ b/tests/approved_files/edit_file_tool_test.test_edit_file_replace_range_beyond_file_end_leaves_file_unchanged.approved.txt
@@ -1,0 +1,19 @@
+Command:
+🛠️ edit-file test.txt replace 5-7 replacement
+
+Result:
+Successfully edited test.txt
+
+Initial file: test.txt
+Initial content:
+--- INITIAL CONTENT START ---
+line1
+line2
+--- INITIAL CONTENT END ---
+
+File after edit: test.txt
+Final content:
+--- FINAL CONTENT START ---
+line1
+line2
+--- FINAL CONTENT END ---

--- a/tests/edit_file_tool_test.py
+++ b/tests/edit_file_tool_test.py
@@ -86,6 +86,18 @@ def test_edit_file_delete_a_line(tmp_path):
     verify_edit_tool(library, "test.txt", initial_content, command, tmp_path=tmp_path)
 
 
+def test_edit_file_delete_range_extending_past_file_end(tmp_path):
+    initial_content = "line1\nline2\nline3"
+    command = "🛠️ edit-file test.txt delete 2-10"
+    verify_edit_tool(library, "test.txt", initial_content, command, tmp_path=tmp_path)
+
+
+def test_edit_file_replace_range_beyond_file_end_leaves_file_unchanged(tmp_path):
+    initial_content = "line1\nline2"
+    command = "🛠️ edit-file test.txt replace 5-7 replacement"
+    verify_edit_tool(library, "test.txt", initial_content, command, tmp_path=tmp_path)
+
+
 def verify_edit_tool(library, setup_file, setup_content, command, tmp_path):
     with temp_directory(tmp_path):
         with open(setup_file, "w", encoding='utf-8') as f:


### PR DESCRIPTION
## Summary
- trim trailing newlines only when an edit reaches the end of a file that originally lacked one
- reuse normalized ranges to decide when to adjust the final line instead of a boolean flag

## Testing
- ./test.sh

------
https://chatgpt.com/codex/tasks/task_e_68c8f4befab4832fa77c3a847ce22d8a