### PR TITLE
Show tool arguments in console display

### DIFF
--- a/tests/approved_files/agent_test.test_agent_says_after_subagent.approved.txt
+++ b/tests/approved_files/agent_test.test_agent_says_after_subagent.approved.txt
@@ -20,6 +20,6 @@ Press Enter to continue or type a message to add:
 # Saved messages:
 user: Create a subagent that says hello, then say goodbye
 assistant: 🛠️ subagent say hello
-user: Result of 🛠️ subagent
+user: Result of 🛠️ subagent say hello
 I successfully said hello
 assistant: goodbye

--- a/tests/approved_files/agent_test.test_nested_agent_test.approved.txt
+++ b/tests/approved_files/agent_test.test_nested_agent_test.approved.txt
@@ -24,5 +24,5 @@ Agent: 🛠️ subagent create another subagent
 # Saved messages:
 user: Create a subagent that creates another subagent
 assistant: 🛠️ subagent create another subagent
-user: Result of 🛠️ subagent
+user: Result of 🛠️ subagent create another subagent
 I successfully created another subagent

--- a/tests/approved_files/agent_test.test_subagent.approved.txt
+++ b/tests/approved_files/agent_test.test_subagent.approved.txt
@@ -16,5 +16,5 @@ Agent: 🛠️ subagent say hello
 # Saved messages:
 user: Create a subagent that says hello
 assistant: 🛠️ subagent say hello
-user: Result of 🛠️ subagent
+user: Result of 🛠️ subagent say hello
 I successfully said hello

--- a/tests/approved_files/agent_test.test_tool_bash.approved.txt
+++ b/tests/approved_files/agent_test.test_tool_bash.approved.txt
@@ -8,5 +8,5 @@ Agent: 🛠️ bash echo hello
 # Saved messages:
 user: use bash
 assistant: 🛠️ bash echo hello
-user: Result of 🛠️ bash
+user: Result of 🛠️ bash echo hello
 hello

--- a/tests/approved_files/agent_test.test_tool_cat.approved.txt
+++ b/tests/approved_files/agent_test.test_tool_cat.approved.txt
@@ -8,5 +8,5 @@ Agent: 🛠️ cat /tmp/test_path/testfile.txt
 # Saved messages:
 user: Test message
 assistant: 🛠️ cat /tmp/test_path/testfile.txt
-user: Result of 🛠️ cat
+user: Result of 🛠️ cat /tmp/test_path/testfile.txt
      1	Hello world

--- a/tests/approved_files/agent_test.test_tool_cat_integration.approved.txt
+++ b/tests/approved_files/agent_test.test_tool_cat_integration.approved.txt
@@ -9,6 +9,6 @@ Agent: 🛠️ cat /tmp/test_path/integration_test.txt
 # Saved messages:
 user: Test message
 assistant: 🛠️ cat /tmp/test_path/integration_test.txt
-user: Result of 🛠️ cat
+user: Result of 🛠️ cat /tmp/test_path/integration_test.txt
      1	Integration test content
      2	Line 2

--- a/tests/approved_files/agent_test.test_tool_ls_integration.approved.txt
+++ b/tests/approved_files/agent_test.test_tool_ls_integration.approved.txt
@@ -11,7 +11,7 @@ Agent: 🛠️ ls /tmp/test_path
 # Saved messages:
 user: Test message
 assistant: 🛠️ ls /tmp/test_path
-user: Result of 🛠️ ls
+user: Result of 🛠️ ls /tmp/test_path
 .
 ..
 file1.txt

--- a/tools/tool_library.py
+++ b/tools/tool_library.py
@@ -17,7 +17,8 @@ class ParsedTool:
         self.tool_instance = tool_instance
 
     def __str__(self):
-        args_str = f"{self.arguments}" if self.arguments else ""
+        if self.arguments:
+            return f"🛠️ {self.name} {self.arguments}"
         return f"🛠️ {self.name}"
 
 


### PR DESCRIPTION
## Summary
- include parsed tool arguments in the string representation so execution logs show full commands
- update approval baselines to reflect the expanded tool execution output

## Testing
- ./test.sh

------
https://chatgpt.com/codex/tasks/task_e_68c99e9351c4832fa88ecca368b125e3