### PR TITLE
r rename Chat dataclass to Messages

### DIFF
--- a/chat.py
+++ b/chat.py
@@ -6,7 +6,7 @@ from typing import List, Dict
 from claude.claude_config import claude_config
 
 @dataclass()
-class Chat:
+class Messages:
     _messages: List[Dict[str, str]] = field(default_factory=list)
 
     def user_says(self, content: str):
@@ -31,24 +31,24 @@ class Chat:
         return str(self._messages)
 
 
-def load_chat() -> 'Chat':
+def load_chat() -> 'Messages':
     session_file = claude_config.session_file_path
     if not os.path.exists(session_file):
-        return Chat()
+        return Messages()
 
     try:
         with open(session_file, 'r', encoding='utf-8') as f:
             chat_data = json.load(f)
-            return Chat(chat_data if isinstance(chat_data, list) else [])
+            return Messages(chat_data if isinstance(chat_data, list) else [])
     except (json.JSONDecodeError, Exception) as e:
         print(f"Warning: Could not load session file {session_file}: {e}", file=sys.stderr)
-        return Chat()
+        return Messages()
 
 
-def save_chat(chat):
+def save_chat(messages):
     session_file = claude_config.session_file_path
     try:
         with open(session_file, 'w', encoding='utf-8') as f:
-            json.dump(chat.to_list(), f, indent=2)
+            json.dump(messages.to_list(), f, indent=2)
     except Exception as e:
         print(f"Warning: Could not save session file {session_file}: {e}", file=sys.stderr)

--- a/main.py
+++ b/main.py
@@ -6,7 +6,7 @@ import sys
 from claude.claude_client import message_claude
 from agent import Agent
 from system_prompt_generator import SystemPromptGenerator
-from chat import Chat, load_chat
+from chat import Messages, load_chat
 from console_display import ConsoleDisplay
 from tools import ToolLibrary
 
@@ -32,7 +32,7 @@ def main():
 
     system_prompt = get_system_prompt()
 
-    chat = load_chat() if continue_session else Chat()
+    chat = load_chat() if continue_session else Messages()
     print("Continuing session" if continue_session else "Starting new session")
 
     if start_message:

--- a/tests/agent_test.py
+++ b/tests/agent_test.py
@@ -4,7 +4,7 @@ from unittest.mock import patch, Mock
 from approvaltests import verify, Options
 
 from agent import Agent
-from chat import Chat
+from chat import Messages
 from console_display import ConsoleDisplay
 from tools import ToolLibrary
 from .test_helpers import (
@@ -130,22 +130,22 @@ def run_chat_test(input_stub, message, claude_stub, rounds=1):
 
     saved_messages = "None"
 
-    def save_chat(chat):
+    def save_chat(messages):
         nonlocal saved_messages
-        saved_messages = "\n".join(f"{msg['role']}: {msg['content']}" for msg in chat)
+        saved_messages = "\n".join(f"{msg['role']}: {msg['content']}" for msg in messages)
 
     system_prompt = "Test system prompt"
     print_spy = PrintSpy()
 
-    chat = Chat()
+    messages = Messages()
     print_spy("Starting new session")
 
     if message:
-        chat.user_says(message)
+        messages.user_says(message)
 
     try:
         agent = Agent(system_prompt, claude_stub, ConsoleDisplay(print_fn=print_spy), ToolLibrary(claude_stub, print_fn=print_spy), save_chat)
-        agent.start(chat, rounds)
+        agent.start(messages, rounds)
     except KeyboardInterrupt:
         pass
 

--- a/tools/subagent_tool.py
+++ b/tools/subagent_tool.py
@@ -1,4 +1,4 @@
-from chat import Chat
+from chat import Messages
 from console_display import ConsoleDisplay
 
 from .base_tool import BaseTool
@@ -42,9 +42,9 @@ class SubagentTool(BaseTool):
             subagent_tools = ToolLibrary(self.message_claude, self.indent_level + 1, self.print_fn)
             subagent = Agent(system_prompt, self.message_claude, self.subagent_display, subagent_tools)
 
-            subagent_chat = Chat()
-            subagent_chat.user_says(args.strip())
-            result = subagent.start(subagent_chat)
+            subagent_messages = Messages()
+            subagent_messages.user_says(args.strip())
+            result = subagent.start(subagent_messages)
             return result
 
         except Exception as e:


### PR DESCRIPTION
## Summary
- rename the chat dataclass to Messages and adjust load/save helpers to use the new name
- update main entrypoint, subagent tool, and tests to instantiate Messages objects

## Testing
- ./test.sh

------
https://chatgpt.com/codex/tasks/task_e_68c9a666f8b0832f87217facb8ae724d