### PR TITLE
b handle windows path parsing in tools

### DIFF
--- a/tools/argument_parser.py
+++ b/tools/argument_parser.py
@@ -1,0 +1,14 @@
+import shlex
+
+
+def create_lexer(text):
+    lexer = shlex.shlex(text, posix=True)
+    lexer.whitespace_split = True
+    lexer.commenters = ''
+    lexer.escape = ''
+    return lexer
+
+
+def split_arguments(text):
+    lexer = create_lexer(text)
+    return list(lexer)

--- a/tools/cat_tool.py
+++ b/tools/cat_tool.py
@@ -1,6 +1,5 @@
-import shlex
-
 from .base_tool import BaseTool
+from .argument_parser import split_arguments
 
 class CatTool(BaseTool):
     name = 'cat'
@@ -33,7 +32,7 @@ class CatTool(BaseTool):
             return None, None, 'STDERR: cat: missing file operand'
 
         try:
-            parts = shlex.split(args)
+            parts = split_arguments(args)
         except ValueError as exc:
             return None, None, f"STDERR: cat: {exc}"
 

--- a/tools/create_file_tool.py
+++ b/tools/create_file_tool.py
@@ -1,6 +1,6 @@
 from .base_tool import BaseTool
+from .argument_parser import create_lexer, split_arguments
 import os
-import shlex
 
 class CreateFileTool(BaseTool):
     name = "create-file"
@@ -33,16 +33,14 @@ class CreateFileTool(BaseTool):
             return 'No filename specified'
 
         try:
-            tokens = shlex.split(args, posix=True)
+            tokens = split_arguments(args)
         except ValueError as e:
             return f"Error parsing arguments: {str(e)}"
 
         if not tokens:
             return 'No filename specified'
 
-        lexer = shlex.shlex(args, posix=True)
-        lexer.whitespace_split = True
-        lexer.commenters = ''
+        lexer = create_lexer(args)
 
         try:
             lexer.get_token()

--- a/tools/edit_file_tool.py
+++ b/tools/edit_file_tool.py
@@ -1,6 +1,6 @@
 from .base_tool import BaseTool
+from .argument_parser import create_lexer, split_arguments
 import os
-import shlex
 from dataclasses import dataclass
 
 @dataclass
@@ -62,7 +62,7 @@ class EditFileTool(BaseTool):
             return None, 'No arguments specified'
 
         try:
-            parts = shlex.split(args, posix=True)
+            parts = split_arguments(args)
         except ValueError as e:
             return None, f"Error parsing arguments: {str(e)}"
 
@@ -71,9 +71,7 @@ class EditFileTool(BaseTool):
 
         filename, edit_mode, line_range_token = parts[:3]
 
-        lexer = shlex.shlex(args, posix=True)
-        lexer.whitespace_split = True
-        lexer.commenters = ''
+        lexer = create_lexer(args)
 
         try:
             lexer.get_token()


### PR DESCRIPTION
## Summary
- add a shared argument parser that disables shlex backslash escaping
- update cat, create-file, and edit-file tools to use the new parser so Windows paths are preserved

## Testing
- ./test.sh

------
https://chatgpt.com/codex/tasks/task_e_68c9a88f31c4832fbf289c315459f885