### PR TITLE
r rename session storage to json file session storage

### DIFF
--- a/infrastructure/json_file_session_storage.py
+++ b/infrastructure/json_file_session_storage.py
@@ -7,7 +7,7 @@ from application.session_storage import SessionStorage
 from .claude.claude_config import claude_config
 
 
-class JsonSessionStorage(SessionStorage):
+class JsonFileSessionStorage(SessionStorage):
 
     def __init__(self, path=None):
         self.path = path or claude_config.session_file_path

--- a/main.py
+++ b/main.py
@@ -8,7 +8,7 @@ from application.chat import Messages
 from application.session_storage import SessionStorage
 from infrastructure.claude.claude_client import ClaudeChat
 from infrastructure.console_display import ConsoleDisplay
-from infrastructure.session_storage import JsonSessionStorage
+from infrastructure.json_file_session_storage import JsonFileSessionStorage
 from system_prompt_generator import SystemPromptGenerator
 from tools import ToolLibrary
 
@@ -23,7 +23,7 @@ def main():
     args = parse_args()
     display = ConsoleDisplay()
     claude_chat = ClaudeChat()
-    session_storage = JsonSessionStorage()
+    session_storage = JsonFileSessionStorage()
     run_session(args, display, session_storage, claude_chat, 999999)
 
 


### PR DESCRIPTION
## Summary
- rename the infrastructure session storage implementation module and class to JsonFileSessionStorage
- update the main entrypoint to import and instantiate the renamed storage

## Testing
- ./test.sh

------
https://chatgpt.com/codex/tasks/task_e_68cc7a596f18832faa10c2149cb19485