### PR TITLE
Add integration tests for Claude client

### DIFF
--- a/tests/claude_client_test.py
+++ b/tests/claude_client_test.py
@@ -1,0 +1,104 @@
+import pytest
+import requests
+
+from infrastructure.claude import claude_client
+from infrastructure.claude.claude_client import ClaudeChat
+from infrastructure.claude.claude_config import claude_config
+
+
+def test_claude_chat_returns_content_text(monkeypatch):
+    stub_claude_config(monkeypatch)
+    captured = {}
+    monkeypatch.setattr(claude_client.requests, "post", create_successful_post(captured))
+    chat = ClaudeChat()
+    system_prompt = "system prompt"
+    messages = [{"role": "user", "content": "Hello"}]
+
+    result = chat(system_prompt, messages)
+
+    assert result == "assistant response"
+    assert captured["url"] == "https://api.anthropic.com/v1/messages"
+    assert captured["headers"] == {
+        "Content-Type": "application/json",
+        "x-api-key": "test-api-key",
+        "anthropic-version": "2023-06-01"
+    }
+    assert captured["json"] == {
+        "model": "test-model",
+        "max_tokens": 4000,
+        "system": system_prompt,
+        "messages": messages
+    }
+
+
+def test_claude_chat_exits_when_content_missing(monkeypatch, capsys):
+    stub_claude_config(monkeypatch)
+    monkeypatch.setattr(claude_client.requests, "post", create_missing_content_post())
+    chat = ClaudeChat()
+
+    with pytest.raises(SystemExit):
+        chat("system", [])
+
+    captured = capsys.readouterr()
+
+    assert captured.err.strip() == "API response missing 'content' field"
+
+
+def test_claude_chat_exits_when_request_fails(monkeypatch, capsys):
+    stub_claude_config(monkeypatch)
+    monkeypatch.setattr(claude_client.requests, "post", create_failing_post())
+    chat = ClaudeChat()
+
+    with pytest.raises(SystemExit):
+        chat("system", [])
+
+    captured = capsys.readouterr()
+
+    assert captured.err.strip() == "API request failed: network down"
+
+
+def stub_claude_config(monkeypatch):
+    values = {
+        claude_config._get_absolute_path("claude-api-key.txt"): "test-api-key",
+        claude_config._get_absolute_path("claude-model.txt"): "test-model"
+    }
+    monkeypatch.setattr(claude_config, "_read_file", lambda filename: values[filename])
+
+
+def create_successful_post(captured):
+    response = ResponseStub({"content": [{"text": "assistant response"}]})
+
+    def post(url, headers, json):
+        captured["url"] = url
+        captured["headers"] = headers
+        captured["json"] = json
+        return response
+
+    return post
+
+
+def create_missing_content_post():
+    response = ResponseStub({})
+
+    def post(url, headers, json):
+        return response
+
+    return post
+
+
+def create_failing_post():
+    def post(url, headers, json):
+        raise requests.exceptions.RequestException("network down")
+
+    return post
+
+
+class ResponseStub:
+    def __init__(self, data):
+        self._data = data
+
+    def json(self):
+        return self._data
+
+    def raise_for_status(self):
+        return None


### PR DESCRIPTION
## Summary
- add integration coverage for ClaudeChat, including successful responses and error handling

## Testing
- ./test.sh

------
https://chatgpt.com/codex/tasks/task_e_68cc7d71aab4832f965135abed227c73