### PR TITLE
r simplify agent feed handling

### DIFF
--- a/application/input_feed.py
+++ b/application/input_feed.py
@@ -1,0 +1,19 @@
+from typing import List
+
+
+class InputFeed:
+
+    def __init__(self, display):
+        self.display = display
+        self._stack: List[str] = []
+
+    def stack(self, message: str):
+        self._stack.append(message)
+
+    def has_stacked_messages(self) -> bool:
+        return bool(self._stack)
+
+    def read(self) -> str:
+        if self._stack:
+            return self._stack.pop()
+        return self.display.input()

--- a/tests/input_feed_test.py
+++ b/tests/input_feed_test.py
@@ -1,0 +1,32 @@
+from application.input_feed import InputFeed
+
+
+class DisplayStub:
+    def __init__(self, value="input"):
+        self.value = value
+        self.calls = 0
+
+    def input(self):
+        self.calls += 1
+        return self.value
+
+
+def test_input_feed_uses_display_input_when_stack_empty():
+    display = DisplayStub("user input")
+    feed = InputFeed(display)
+
+    result = feed.read()
+
+    assert result == "user input"
+    assert display.calls == 1
+
+
+def test_input_feed_returns_stacked_message_before_display():
+    display = DisplayStub("user input")
+    feed = InputFeed(display)
+    feed.stack("stacked")
+
+    result = feed.read()
+
+    assert result == "stacked"
+    assert display.calls == 0


### PR DESCRIPTION
## Summary
- require Agent to rely on an injected InputFeed, reading the first turn from the feed inside the main loop before answering
- update SubagentTool to create its own InputFeed and seed the subagent conversation through the feed

## Testing
- ./test.sh

------
https://chatgpt.com/codex/tasks/task_e_68ce5c0093a4832fbfd3b189aa4fdde4