### PR TITLE
Remove tool_about_to_execute hook usage

### DIFF
--- a/application/agent.py
+++ b/application/agent.py
@@ -34,7 +34,6 @@ class Agent:
                 tool = self.tools.parse_tool(answer)
 
                 if tool:
-                    self.display.tool_about_to_execute(tool)
                     tool_result = self.tools.execute_parsed_tool(tool)
                     self.display.tool_result(tool_result)
                     if tool.is_completing():

--- a/application/display.py
+++ b/application/display.py
@@ -6,9 +6,6 @@ class Display(Protocol):
     def assistant_says(self, message) -> None:
         ...
 
-    def tool_about_to_execute(self, parsed_tool) -> None:
-        ...
-
     def tool_result(self, result) -> None:
         ...
 

--- a/infrastructure/console_display.py
+++ b/infrastructure/console_display.py
@@ -18,9 +18,6 @@ class ConsoleDisplay(Display):
             for line in lines[1:]:
                 self.print(f"{self.base_indent}{line}")
 
-    def tool_about_to_execute(self, parsed_tool):
-        pass
-
     def tool_result(self, result):
         lines = str(result).split('\n')
         first_three_lines = '\n'.join(lines[:3])


### PR DESCRIPTION
## Summary
- remove the tool_about_to_execute hook from the display protocol
- drop the no-op console display implementation and agent call site

## Testing
- ./test.sh

------
https://chatgpt.com/codex/tasks/task_e_68d040d61e24832f9737a32a21c87ebc