### PR TITLE
Rename message_claude parameter to chat in ToolLibrary

### DIFF
--- a/tools/tool_library.py
+++ b/tools/tool_library.py
@@ -28,10 +28,10 @@ class ParsedTool:
 
 
 class ToolLibrary:
-    def __init__(self, message_claude: Chat | None = None, indent_level=0, print_fn=print):
-        if message_claude is None:
-            message_claude = lambda system_prompt, messages: ''
-        self.message_claude: Chat = message_claude
+    def __init__(self, chat: Chat | None = None, indent_level=0, print_fn=print):
+        if chat is None:
+            chat = lambda system_prompt, messages: ''
+        self.chat: Chat = chat
         self.indent_level = indent_level
         self.print_fn = print_fn
         static_tools = self._create_static_tools()
@@ -46,7 +46,7 @@ class ToolLibrary:
             CatTool(self.run_command),
             CreateFileTool(self.run_command),
             EditFileTool(self.run_command),
-            SubagentTool(self.run_command, self.message_claude, self.indent_level, self.print_fn),
+            SubagentTool(self.run_command, self.chat, self.indent_level, self.print_fn),
             CompleteTaskTool(self.run_command),
             BashTool(self.run_command)
         ]


### PR DESCRIPTION
## Summary
- rename the ToolLibrary constructor argument from message_claude to chat
- adjust internal storage and SubagentTool wiring to use the chat attribute

## Testing
- ./test.sh

------
https://chatgpt.com/codex/tasks/task_e_68d042075434832f9318175a68690c35