### PR TITLE
Refactor Claude config instantiation

### DIFF
--- a/simple_agent/infrastructure/claude/claude_client.py
+++ b/simple_agent/infrastructure/claude/claude_client.py
@@ -3,7 +3,7 @@ import logging
 import requests
 
 from simple_agent.application.llm import LLM, ChatMessages
-from .claude_config import claude_config
+from .claude_config import load_claude_config
 
 logger = logging.getLogger(__name__)
 logging.basicConfig(filename='request.log', encoding='utf-8', level=logging.DEBUG)
@@ -16,10 +16,13 @@ class ClaudeClientError(RuntimeError):
 
 class ClaudeLLM(LLM):
 
+    def __init__(self, config=None):
+        self._config = config or load_claude_config()
+
     def __call__(self, system_prompt: str, messages: ChatMessages) -> str:
         url = "https://api.anthropic.com/v1/messages"
-        api_key = claude_config.api_key
-        model = claude_config.model
+        api_key = self._config.api_key
+        model = self._config.model
         headers = {
             "Content-Type": "application/json",
             "x-api-key": api_key,

--- a/simple_agent/infrastructure/claude/claude_config.py
+++ b/simple_agent/infrastructure/claude/claude_config.py
@@ -2,24 +2,23 @@ import os
 import sys
 import tomllib
 
+
+def load_claude_config():
+    script_dir = _script_dir()
+    config_path = os.path.join(os.getcwd(), "simple-agent.toml")
+    config = _read_config(config_path)
+    return ClaudeConfig(config, script_dir)
+
+
+def default_session_file_path():
+    script_dir = _script_dir()
+    return os.path.join(script_dir, "claude-session.json")
+
+
 class ClaudeConfig:
-    def __init__(self):
-        self._script_dir = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
-        self._config = self._load_config()
-
-    def _load_config(self):
-        cwd_config_path = os.path.join(os.getcwd(), "simple-agent.toml")
-        if not os.path.exists(cwd_config_path):
-            print(f"Error: simple-agent.toml not found in current directory ({os.getcwd()})", file=sys.stderr)
-            print("Please create a simple-agent.toml file with your Claude configuration", file=sys.stderr)
-            sys.exit(1)
-
-        try:
-            with open(cwd_config_path, 'rb') as f:
-                return tomllib.load(f)
-        except Exception as e:
-            print(f"Error reading {cwd_config_path}: {e}", file=sys.stderr)
-            sys.exit(1)
+    def __init__(self, config, script_dir):
+        self._config = config
+        self._script_dir = script_dir
 
     @property
     def api_key(self):
@@ -39,4 +38,19 @@ class ClaudeConfig:
     def session_file_path(self):
         return os.path.join(self._script_dir, "claude-session.json")
 
-claude_config = ClaudeConfig()
+
+def _script_dir():
+    return os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+
+def _read_config(path):
+    if not os.path.exists(path):
+        print(f"Error: simple-agent.toml not found in current directory ({os.getcwd()})", file=sys.stderr)
+        print("Please create a simple-agent.toml file with your Claude configuration", file=sys.stderr)
+        sys.exit(1)
+    try:
+        with open(path, 'rb') as handle:
+            return tomllib.load(handle)
+    except Exception as error:
+        print(f"Error reading {path}: {error}", file=sys.stderr)
+        sys.exit(1)

--- a/simple_agent/infrastructure/json_file_session_storage.py
+++ b/simple_agent/infrastructure/json_file_session_storage.py
@@ -4,13 +4,13 @@ import sys
 
 from simple_agent.application.llm import Messages
 from simple_agent.application.session_storage import SessionStorage
-from .claude.claude_config import claude_config
+from .claude.claude_config import default_session_file_path
 
 
 class JsonFileSessionStorage(SessionStorage):
 
     def __init__(self, path=None):
-        self.path = path or claude_config.session_file_path
+        self.path = path or default_session_file_path()
 
     def load(self) -> Messages:
         if not os.path.exists(self.path):


### PR DESCRIPTION
## Summary
- load the Claude configuration when constructing ClaudeLLM so the module no longer relies on a lazy global instance
- expose helpers for loading the config and for computing the default session path so other adapters can use them without side effects

## Testing
- ./test.sh

------
https://chatgpt.com/codex/tasks/task_e_68e23cb86ed4832facf644f1ae5183f7