### PR TITLE
Fix Claude session file location

### DIFF
--- a/simple_agent/infrastructure/claude/claude_config.py
+++ b/simple_agent/infrastructure/claude/claude_config.py
@@ -11,8 +11,7 @@ def load_claude_config():
 
 
 def default_session_file_path():
-    script_dir = _script_dir()
-    return os.path.join(script_dir, "claude-session.json")
+    return os.path.join(os.getcwd(), "claude-session.json")
 
 
 class ClaudeConfig:
@@ -36,7 +35,7 @@ class ClaudeConfig:
 
     @property
     def session_file_path(self):
-        return os.path.join(self._script_dir, "claude-session.json")
+        return default_session_file_path()
 
 
 def _script_dir():


### PR DESCRIPTION
## Summary
- update the default Claude session file path to use the current working directory
- ensure the configuration uses the shared default path helper for the session file

## Testing
- ./test.sh

------
https://chatgpt.com/codex/tasks/task_e_68e24b85fb64832fbbc3dca392872801