### PR TITLE
Add approval test for WriteTodos tool

### DIFF
--- a/simple_agent/tools/tool_library.py
+++ b/simple_agent/tools/tool_library.py
@@ -12,6 +12,7 @@ from .edit_file_tool import EditFileTool
 from .ls_tool import LsTool
 from .patch_file_tool import PatchFileTool
 from .subagent_tool import SubagentTool
+from .write_todos_tool import WriteTodosTool
 
 
 class ParsedTool:
@@ -46,6 +47,7 @@ class ToolLibrary:
             EditFileTool(self.run_command),
             PatchFileTool(self.run_command),
             SubagentTool(self.run_command, self.llm, self.indent_level, self.io),
+            WriteTodosTool(self.run_command),
             CompleteTaskTool(self.run_command),
             BashTool(self.run_command)
         ]

--- a/simple_agent/tools/write_todos_tool.py
+++ b/simple_agent/tools/write_todos_tool.py
@@ -1,0 +1,34 @@
+from pathlib import Path
+
+from simple_agent.application.tool_result import ContinueResult
+
+from .base_tool import BaseTool
+
+
+class WriteTodosTool(BaseTool):
+    name = "WriteTodos"
+    description = "Create or update .todos.md with provided markdown content"
+    arguments = [
+        {
+            "name": "content",
+            "type": "string",
+            "required": True,
+            "description": "Markdown text to write into .todos.md"
+        }
+    ]
+    examples = [
+        "🛠️ WriteTodos ## Todo\\n- Item 1",
+        "🛠️ WriteTodos\\n## Todo\\n- Feature exploration\\n\\n## Doing\\n- Implementing tool\\n\\n## Done\\n- Initial setup"
+    ]
+
+    def __init__(self, runcommand):
+        super().__init__()
+        self.runcommand = runcommand
+
+    def execute(self, args):
+        if not args or not args.strip():
+            return ContinueResult("No todo content provided")
+        content = args
+        path = Path(".todos.md")
+        path.write_text(content, encoding="utf-8")
+        return ContinueResult("Updated .todos.md")

--- a/tests/approved_files/system_prompt_generator_test.test_generate_tools_content_only.approved.txt
+++ b/tests/approved_files/system_prompt_generator_test.test_generate_tools_content_only.approved.txt
@@ -86,6 +86,18 @@ Examples:
 🛠️ subagent Write a Python function to calculate fibonacci numbers
 🛠️ subagent Create a simple HTML page with a form
 
+## WriteTodos
+Create or update .todos.md with provided markdown content
+
+Arguments:
+ - content: string (required) - Markdown text to write into .todos.md
+
+Usage: 🛠️ WriteTodos <content>
+
+Examples:
+🛠️ WriteTodos ## Todo\n- Item 1
+🛠️ WriteTodos\n## Todo\n- Feature exploration\n\n## Doing\n- Implementing tool\n\n## Done\n- Initial setup
+
 ## complete-task
 Signal task completion with a summary of what was accomplished
 

--- a/tests/approved_files/write_todos_tool_test.test_write_todos_creates_markdown_file.approved.txt
+++ b/tests/approved_files/write_todos_tool_test.test_write_todos_creates_markdown_file.approved.txt
@@ -1,0 +1,24 @@
+Command:
+🛠️ WriteTodos ## Todo
+- Item 1
+
+## Doing
+- Work in progress
+
+## Done
+- Completed
+
+Result:
+Updated .todos.md
+
+File content:
+--- FILE CONTENT START ---
+## Todo
+- Item 1
+
+## Doing
+- Work in progress
+
+## Done
+- Completed
+--- FILE CONTENT END ---

--- a/tests/write_todos_tool_test.py
+++ b/tests/write_todos_tool_test.py
@@ -1,0 +1,22 @@
+from pathlib import Path
+
+from approvaltests import Options, verify
+
+from simple_agent.tools.tool_library import ToolLibrary
+from .test_helpers import all_scrubbers, temp_directory
+
+library = ToolLibrary()
+
+
+def test_write_todos_creates_markdown_file(tmp_path):
+    command = "🛠️ WriteTodos ## Todo\n- Item 1\n\n## Doing\n- Work in progress\n\n## Done\n- Completed"
+
+    with temp_directory(tmp_path):
+        tool = library.parse_tool(command)
+        result = library.execute_parsed_tool(tool)
+
+        content = Path(".todos.md").read_text(encoding="utf-8")
+        verify(
+            f"Command:\n{command}\n\nResult:\n{result}\n\nFile content:\n--- FILE CONTENT START ---\n{content}\n--- FILE CONTENT END ---",
+            options=Options().with_scrubber(all_scrubbers())
+        )


### PR DESCRIPTION
## Summary
- add an approval test that exercises the WriteTodos tool end-to-end
- record the approved output verifying the markdown written to .todos.md

## Testing
- ./test.sh

------
https://chatgpt.com/codex/tasks/task_e_68e2e8cf952c832f98ea046eeb9d5ac6